### PR TITLE
Unify focus score response fields

### DIFF
--- a/src/controllers/focus_controller.py
+++ b/src/controllers/focus_controller.py
@@ -126,18 +126,20 @@ async def get_focus_score(session_id: str = "default"):
         if monitor is None:
             raise HTTPException(status_code=404, detail=f"Session {session_id} not found")
         
-        score = monitor.get_focus_score()
+        raw_score = monitor.get_focus_score()
         status = monitor.get_current_status()
         
         # Calculate session duration
         session_duration = 0.0
         if status.get('current_session'):
-            session_duration = status['current_session'].get('duration_minutes', 0.0)
-        
+            session_duration = status['current_session'].get(
+                'duration_minutes', 0.0
+            )
+
         return FocusScoreResponse(
-            score=score,
+            score=raw_score * 20,  # Convert 0-5 scale to 0-100
             timestamp=datetime.now().isoformat(),
-            session_duration_minutes=session_duration
+            session_duration_minutes=session_duration,
         )
     except Exception as e:
         logger.error(f"Failed to get focus score: {e}")

--- a/src/models/focus_models.py
+++ b/src/models/focus_models.py
@@ -1,12 +1,13 @@
-"""
-Data models for focus monitoring
-"""
+"""Data models for focus monitoring"""
+
 from typing import Optional, Dict, Any
-from pydantic import BaseModel, Field, field_validator
+
+from pydantic import BaseModel, Field
 
 
 class StatusResponse(BaseModel):
     """Response model for monitoring status"""
+
     is_initialized: bool
     person_detected: Optional[bool]
     current_session: Optional[Dict[str, Any]]
@@ -15,6 +16,7 @@ class StatusResponse(BaseModel):
 
 class SummaryResponse(BaseModel):
     """Response model for time tracking summary"""
+
     total_focus_minutes: float
     total_leave_minutes: float
     focus_sessions: int
@@ -23,6 +25,7 @@ class SummaryResponse(BaseModel):
 
 class TimeRecord(BaseModel):
     """Model for individual time record"""
+
     type: str
     start: float
     end: float
@@ -32,11 +35,25 @@ class TimeRecord(BaseModel):
 
 class FocusScoreResponse(BaseModel):
     """Response model for focus score"""
-    focus_score: int = Field(..., ge=0, le=100, description="Focus score (0-100)")
-    confidence: Optional[str] = Field(None, description="Confidence level of the analysis")
+
+    score: float = Field(..., ge=0, le=100, description="Focus score (0-100)")
+    confidence: Optional[str] = Field(
+        None, description="Confidence level of the analysis"
+    )
     processing_time: Optional[float] = Field(
-        None, 
-        description="Total processing time in seconds from request initiation to response completion. Includes image encoding, OpenAI API call latency, response parsing, and network overhead. Used for performance monitoring, API optimization, and user experience analysis."
+        None,
+        description=(
+            "Total processing time in seconds from request initiation to "
+            "response completion. Includes image encoding, OpenAI API call "
+            "latency, response parsing, and network overhead. Used for "
+            "performance monitoring, API optimization, and user experience analysis."
+        ),
+    )
+    timestamp: Optional[str] = Field(
+        None, description="ISO timestamp when the score was generated"
+    )
+    session_duration_minutes: Optional[float] = Field(
+        None, description="Duration of the current session in minutes"
     )
 
 
@@ -47,6 +64,7 @@ class FocusScoreResponse(BaseModel):
 
 class HealthResponse(BaseModel):
     """Response model for health check"""
+
     status: str
     monitoring_active: bool
     timestamp: str
@@ -54,6 +72,7 @@ class HealthResponse(BaseModel):
 
 class MonitorStartResponse(BaseModel):
     """Response model for starting monitoring"""
+
     status: str
     message: str
     config: Dict[str, Any]
@@ -61,6 +80,7 @@ class MonitorStartResponse(BaseModel):
 
 class MonitorStopResponse(BaseModel):
     """Response model for stopping monitoring"""
+
     status: str
     message: str
     final_stats: Dict[str, Any]
@@ -68,5 +88,7 @@ class MonitorStopResponse(BaseModel):
 
 class LatestRecordResponse(BaseModel):
     """Response model for latest record"""
+
     latest_record: Optional[str] = None
     message: Optional[str] = None
+

--- a/src/services/focus_score_service.py
+++ b/src/services/focus_score_service.py
@@ -61,7 +61,7 @@ class FocusScoreService:
             img_b64: Base64 encoded image string
             
         Returns:
-            Tuple of (focus_score, processing_time)
+            Tuple of (score, processing_time)
             
         Raises:
             HTTPException: For API errors or invalid responses
@@ -90,8 +90,10 @@ class FocusScoreService:
             )
             
             payload = response.choices[0].message.model_dump()
-            score_data = openai.pydantic_v1.parse_raw_as(FocusScoreResponse, payload['content'])
-            score = score_data.focus_score
+            score_data = openai.pydantic_v1.parse_raw_as(
+                FocusScoreResponse, payload["content"]
+            )
+            score = score_data.score
 
             if not (0 <= score <= 100):
                 raise ValueError(f"Returned score is out of valid range: {score}")
@@ -145,9 +147,9 @@ class FocusScoreService:
             score, processing_time = await self.analyze_image_base64(img_b64)
             
             return FocusScoreResponse(
-                focus_score=score,
+                score=score,
                 confidence=CONFIDENCE_HIGH if 0 <= score <= 100 else CONFIDENCE_LOW,
-                processing_time=processing_time
+                processing_time=processing_time,
             )
         except Exception as e:
             logger.error(f"Error processing uploaded file: {e}")


### PR DESCRIPTION
## Summary
- refactor FocusScoreResponse to use `score` field and optional metadata
- update focus score service to parse and return new model
- map monitor focus score to 0-100 scale in controller

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_b_689b54afad0c8324891e9ad398fa5e23